### PR TITLE
enhance: Handle disabling ipv4 and ipv6

### DIFF
--- a/pkg/waf/waf.go
+++ b/pkg/waf/waf.go
@@ -547,43 +547,47 @@ func (w *WAF) Init(ctx context.Context) error {
 func (w *WAF) UpdateSetsContent(ctx context.Context, d Decisions) error {
 	var err error
 
-	for action, ips := range d.V4Add {
-		if action == "fallback" {
-			action = strings.ToLower(w.config.FallbackAction)
+	if w.config.DisableIPv4 == nil || !*w.config.DisableIPv4 {
+		for action, ips := range d.V4Add {
+			if action == "fallback" {
+				action = strings.ToLower(w.config.FallbackAction)
+			}
+
+			for _, ip := range ips {
+				w.ipsetManager.AddIp(*ip, action)
+			}
 		}
 
-		for _, ip := range ips {
-			w.ipsetManager.AddIp(*ip, action)
-		}
-	}
+		for action, ips := range d.V4Del {
+			if action == "fallback" {
+				action = strings.ToLower(w.config.FallbackAction)
+			}
 
-	for action, ips := range d.V4Del {
-		if action == "fallback" {
-			action = strings.ToLower(w.config.FallbackAction)
-		}
-
-		for _, ip := range ips {
-			w.ipsetManager.DeleteIp(*ip, action)
-		}
-	}
-
-	for action, ips := range d.V6Add {
-		if action == "fallback" {
-			action = strings.ToLower(w.config.FallbackAction)
-		}
-
-		for _, ip := range ips {
-			w.ipsetManager.AddIp(*ip, action)
+			for _, ip := range ips {
+				w.ipsetManager.DeleteIp(*ip, action)
+			}
 		}
 	}
 
-	for action, ips := range d.V6Del {
-		if action == "fallback" {
-			action = strings.ToLower(w.config.FallbackAction)
+	if w.config.DisableIPv6 == nil || !*w.config.DisableIPv6 {
+		for action, ips := range d.V6Add {
+			if action == "fallback" {
+				action = strings.ToLower(w.config.FallbackAction)
+			}
+
+			for _, ip := range ips {
+				w.ipsetManager.AddIp(*ip, action)
+			}
 		}
 
-		for _, ip := range ips {
-			w.ipsetManager.DeleteIp(*ip, action)
+		for action, ips := range d.V6Del {
+			if action == "fallback" {
+				action = strings.ToLower(w.config.FallbackAction)
+			}
+
+			for _, ip := range ips {
+				w.ipsetManager.DeleteIp(*ip, action)
+			}
 		}
 	}
 


### PR DESCRIPTION
fix #84 

### PR title
Add global and per-WAF disable_ipv4/disable_ipv6 with inheritance

### What
- Added root-level `disable_ipv4` and `disable_ipv6`.
- Added per-WAF `disable_ipv4` and `disable_ipv6` in each `waf_config` entry.
- Inheritance: per-WAF overrides root; if not set per-WAF, inherits from root.
- Enforcement: `UpdateSetsContent` skips both add and delete operations for the disabled IP family.

### Why
- Allow globally disabling an IP family or overriding per WAF to opt-in/out.

### Behavior
- Defaults to enabled for both families (flags default to false).
- If disabled, both additions and deletions for that IP family are skipped.

### Env vars
- Root: `BOUNCER_DISABLE_IPV4`, `BOUNCER_DISABLE_IPV6`
- Per-WAF: `BOUNCER_WAF_CONFIG_<N>_DISABLE_IPV4`, `BOUNCER_WAF_CONFIG_<N>_DISABLE_IPV6`

### Example YAML

Root only:
```yaml
api_key: ${API_KEY}
api_url: "http://127.0.0.1:8080/"
update_frequency: 10s

disable_ipv6: true

waf_config:
  - web_acl_name: mywebacl
    fallback_action: ban
    rule_group_name: crowdsec-rule-group
    scope: REGIONAL
    region: eu-west-1
    ipset_prefix: crowdsec-blocklist
```

Per-WAF overrides:
```yaml
api_key: ${API_KEY}
api_url: "http://127.0.0.1:8080/"
update_frequency: 10s

waf_config:
  - web_acl_name: ipv4onlywebcl
    disable_ipv6: true    # override: disable IPv6 for this WAF
    fallback_action: ban
    rule_group_name: crowdsec-rule-group
    scope: REGIONAL
    region: eu-west-1
    ipset_prefix: crowdsec-blocklist
  - web_acl_name: ipv6onlywebcl
    disable_ipv4: true    # override: disable IPv4 for this WAF
    fallback_action: ban
    rule_group_name: crowdsec-rule-group
    scope: REGIONAL
    region: eu-west-1
    ipset_prefix: crowdsec-blocklist
```

- Backward compatibility: no change unless the new flags are set.