### PR TITLE
feat: allow acl to be delegated

### DIFF
--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -45,7 +45,7 @@ type AclConfig struct {
 	CloudWatchMetricName string `yaml:"cloudwatch_metric_name"`
 	SampleRequests       bool   `yaml:"sample_requests"`
 	CleanOnStart         bool   `yaml:"remove_sets_on_start"`
-	DelegateAclManagement bool   `yaml:"delegate_acl_management"`
+	UseExistingRuleGroup bool   `yaml:"use_existing_rule_group"`
 }
 
 var ValidActions = []string{"ban", "captcha", "count"}
@@ -131,11 +131,11 @@ func getConfigFromEnv(config *bouncerConfig) {
 						log.Warnf("Invalid value for %s: %s, defaulting to false", key, value)
 						acl.CleanOnStart = false
 					}
-				case "DELEGATE_ACL_MANAGEMENT":
-					acl.DelegateAclManagement, err = strconv.ParseBool(value)
+				case "USE_EXISTING_RULE_GROUP":
+					acl.UseExistingRuleGroup, err = strconv.ParseBool(value)
 					if err != nil {
 						log.Warnf("Invalid value for %s: %s, defaulting to false", key, value)
-						acl.DelegateAclManagement = false
+						acl.UseExistingRuleGroup = false
 					}
 				}
 			} else {

--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -45,6 +45,7 @@ type AclConfig struct {
 	CloudWatchMetricName string `yaml:"cloudwatch_metric_name"`
 	SampleRequests       bool   `yaml:"sample_requests"`
 	CleanOnStart         bool   `yaml:"remove_sets_on_start"`
+	DelegateAclManagement bool   `yaml:"delegate_acl_management"`
 }
 
 var ValidActions = []string{"ban", "captcha", "count"}
@@ -129,6 +130,12 @@ func getConfigFromEnv(config *bouncerConfig) {
 					if err != nil {
 						log.Warnf("Invalid value for %s: %s, defaulting to false", key, value)
 						acl.CleanOnStart = false
+					}
+				case "DELEGATE_ACL_MANAGEMENT":
+					acl.DelegateAclManagement, err = strconv.ParseBool(value)
+					if err != nil {
+						log.Warnf("Invalid value for %s: %s, defaulting to false", key, value)
+						acl.DelegateAclManagement = false
 					}
 				}
 			} else {

--- a/pkg/waf/waf.go
+++ b/pkg/waf/waf.go
@@ -446,14 +446,16 @@ func (w *WAF) CleanupAcl(ctx context.Context, acl *wafv2types.WebACL, token *str
 			return fmt.Errorf("failed to get RuleGroup %s: %w", w.config.RuleGroupName, err)
 		}
 
-		w.Logger.Debugf("Deleting RuleGroup %s", w.config.RuleGroupName)
-
 		if !w.config.UseExistingRuleGroup {
+			w.Logger.Debugf("Deleting RuleGroup %s", w.config.RuleGroupName)
+
 			err = w.DeleteRuleGroup(ctx, w.config.RuleGroupName, token, w.ruleGroupsInfos[w.config.RuleGroupName].Id)
 			if err != nil {
 				return fmt.Errorf("failed to delete RuleGroup %s: %w", w.config.RuleGroupName, err)
 			}
 		} else {
+			w.Logger.Debugf("Cleaning RuleGroup %s", w.config.RuleGroupName)
+
 			err = w.UnassignRulesFromRuleGroup(ctx, w.config.RuleGroupName, token, w.ruleGroupsInfos[w.config.RuleGroupName].Id)
 			if err != nil {
 				return fmt.Errorf("failed to unassign Rules from RuleGroup %s: %w", w.config.RuleGroupName, err)

--- a/pkg/waf/waf.go
+++ b/pkg/waf/waf.go
@@ -574,6 +574,12 @@ func (w *WAF) Init(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to add RuleGroup %s to WebACL %s: %w", w.config.RuleGroupName, w.config.WebACLName, err)
 		}
+	} else {
+		err = w.GetRuleGroup(ctx, w.config.RuleGroupName)
+
+		if err != nil {
+			return fmt.Errorf("failed to get RuleGroup %s: %w", w.config.RuleGroupName, err)
+		}
 	}
 
 	return nil

--- a/pkg/waf/waf.go
+++ b/pkg/waf/waf.go
@@ -475,6 +475,8 @@ func (w *WAF) CleanupAcl(ctx context.Context, acl *wafv2types.WebACL, token *str
 
 func (w *WAF) Cleanup(ctx context.Context) error {
 	var err error
+	var acl *wafv2types.WebACL
+	var token *string
 
 	w.lock.Lock()
 	defer w.lock.Unlock()
@@ -484,8 +486,8 @@ func (w *WAF) Cleanup(ctx context.Context) error {
 		return fmt.Errorf("failed to list WAF resources: %w", err)
 	}
 
-	if !w.config.DelegateAclManagement {
-		acl, token, err := w.GetWebACL(ctx, w.config.WebACLName, w.aclsInfo[w.config.WebACLName].Id)
+	if !w.config.UseExistingRuleGroup {
+		acl, token, err = w.GetWebACL(ctx, w.config.WebACLName, w.aclsInfo[w.config.WebACLName].Id)
 		if err != nil {
 			return fmt.Errorf("failed to get WebACL: %w", err)
 		}
@@ -496,9 +498,10 @@ func (w *WAF) Cleanup(ctx context.Context) error {
 
 func (w *WAF) ListResources(ctx context.Context) (map[string]Acl, map[string]IpSet, map[string]RuleGroup, error) {
 	var err error
+	var acls map[string]Acl
 
-	if !w.config.DelegateAclManagement {
-		acls, err := w.ListWebACL(ctx)
+	if !w.config.UseExistingRuleGroup {
+		acls, err = w.ListWebACL(ctx)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -519,6 +522,9 @@ func (w *WAF) ListResources(ctx context.Context) (map[string]Acl, map[string]IpS
 
 func (w *WAF) Init(ctx context.Context) error {
 	var err error
+	var acl *wafv2types.WebACL
+	var token *string
+
 	w.aclsInfo, w.setsInfos, w.ruleGroupsInfos, err = w.ListResources(ctx)
 
 	if err != nil {
@@ -541,7 +547,7 @@ func (w *WAF) Init(ctx context.Context) error {
 			return fmt.Errorf("WebACL %s does not exist in region %s", w.config.WebACLName, w.config.Region)
 		}
 
-		acl, token, err := w.GetWebACL(ctx, w.config.WebACLName, w.aclsInfo[w.config.WebACLName].Id)
+		acl, token, err = w.GetWebACL(ctx, w.config.WebACLName, w.aclsInfo[w.config.WebACLName].Id)
 
 		if err != nil {
 			return fmt.Errorf("failed to get WebACL: %w", err)
@@ -583,7 +589,7 @@ func (w *WAF) Init(ctx context.Context) error {
 			return fmt.Errorf("failed to add RuleGroup %s to WebACL %s: %w", w.config.RuleGroupName, w.config.WebACLName, err)
 		}
 	} else {
-		err = w.GetRuleGroup(ctx, w.config.RuleGroupName)
+		_, _, err = w.GetRuleGroup(ctx, w.config.RuleGroupName)
 
 		if err != nil {
 			return fmt.Errorf("failed to get RuleGroup %s: %w", w.config.RuleGroupName, err)

--- a/pkg/waf/waf.go
+++ b/pkg/waf/waf.go
@@ -433,7 +433,7 @@ func (w *WAF) GetRuleGroup(ctx context.Context, ruleGroupname string) (string, w
 }
 
 func (w *WAF) CleanupAcl(ctx context.Context, acl *wafv2types.WebACL, token *string, allSets bool) error {
-	if !w.config.DelegateAclManagement {
+	if !w.config.UseExistingRuleGroup {
 		err := w.RemoveRuleGroupFromACL(ctx, acl, token)
 		if err != nil {
 			return fmt.Errorf("error removing rule group from ACL: %w", err)
@@ -448,7 +448,7 @@ func (w *WAF) CleanupAcl(ctx context.Context, acl *wafv2types.WebACL, token *str
 
 		w.Logger.Debugf("Deleting RuleGroup %s", w.config.RuleGroupName)
 
-		if !w.config.DelegateAclManagement {
+		if !w.config.UseExistingRuleGroup {
 			err = w.DeleteRuleGroup(ctx, w.config.RuleGroupName, token, w.ruleGroupsInfos[w.config.RuleGroupName].Id)
 			if err != nil {
 				return fmt.Errorf("failed to delete RuleGroup %s: %w", w.config.RuleGroupName, err)
@@ -552,7 +552,7 @@ func (w *WAF) Init(ctx context.Context) error {
 		return fmt.Errorf("failed to list resources: %w", err)
 	}
 
-	if !w.config.DelegateAclManagement {
+	if !w.config.UseExistingRuleGroup {
 		err = w.CreateRuleGroup(ctx, w.config.RuleGroupName)
 
 		if err != nil {

--- a/pkg/waf/waf.go
+++ b/pkg/waf/waf.go
@@ -484,9 +484,11 @@ func (w *WAF) Cleanup(ctx context.Context) error {
 		return fmt.Errorf("failed to list WAF resources: %w", err)
 	}
 
-	acl, token, err := w.GetWebACL(ctx, w.config.WebACLName, w.aclsInfo[w.config.WebACLName].Id)
-	if err != nil {
-		return fmt.Errorf("failed to get WebACL: %w", err)
+	if !w.config.DelegateAclManagement {
+		acl, token, err := w.GetWebACL(ctx, w.config.WebACLName, w.aclsInfo[w.config.WebACLName].Id)
+		if err != nil {
+			return fmt.Errorf("failed to get WebACL: %w", err)
+		}
 	}
 
 	return w.CleanupAcl(ctx, acl, token, false)
@@ -495,9 +497,11 @@ func (w *WAF) Cleanup(ctx context.Context) error {
 func (w *WAF) ListResources(ctx context.Context) (map[string]Acl, map[string]IpSet, map[string]RuleGroup, error) {
 	var err error
 
-	acls, err := w.ListWebACL(ctx)
-	if err != nil {
-		return nil, nil, nil, err
+	if !w.config.DelegateAclManagement {
+		acls, err := w.ListWebACL(ctx)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 	}
 
 	sets, err := w.ListIpSet(ctx)
@@ -521,8 +525,10 @@ func (w *WAF) Init(ctx context.Context) error {
 		return fmt.Errorf("failed to list resources: %w", err)
 	}
 
-	w.Logger.Tracef("Found %d WebACLs", len(w.aclsInfo))
-	w.Logger.Tracef("ACLs: %+v", w.aclsInfo)
+	if !w.config.UseExistingRuleGroup {
+		w.Logger.Tracef("Found %d WebACLs", len(w.aclsInfo))
+		w.Logger.Tracef("ACLs: %+v", w.aclsInfo)
+	}
 
 	w.Logger.Tracef("Found %d IPSets", len(w.setsInfos))
 	w.Logger.Tracef("IPSets: %+v", w.setsInfos)
@@ -530,14 +536,16 @@ func (w *WAF) Init(ctx context.Context) error {
 	w.Logger.Tracef("Found %d RuleGroups", len(w.ruleGroupsInfos))
 	w.Logger.Tracef("RuleGroups: %+v", w.ruleGroupsInfos)
 
-	if _, ok := w.aclsInfo[w.config.WebACLName]; !ok {
-		return fmt.Errorf("WebACL %s does not exist in region %s", w.config.WebACLName, w.config.Region)
-	}
+	if !w.config.UseExistingRuleGroup {
+		if _, ok := w.aclsInfo[w.config.WebACLName]; !ok {
+			return fmt.Errorf("WebACL %s does not exist in region %s", w.config.WebACLName, w.config.Region)
+		}
 
-	acl, token, err := w.GetWebACL(ctx, w.config.WebACLName, w.aclsInfo[w.config.WebACLName].Id)
+		acl, token, err := w.GetWebACL(ctx, w.config.WebACLName, w.aclsInfo[w.config.WebACLName].Id)
 
-	if err != nil {
-		return fmt.Errorf("failed to get WebACL: %w", err)
+		if err != nil {
+			return fmt.Errorf("failed to get WebACL: %w", err)
+		}
 	}
 
 	w.ipsetManager = NewIPSetManager(w.config.IpsetPrefix, w.config.Scope, w.client, w.Logger)

--- a/pkg/waf/waf.go
+++ b/pkg/waf/waf.go
@@ -221,6 +221,23 @@ func (w *WAF) DeleteRuleGroup(ctx context.Context, ruleGroupName string, token s
 	return err
 }
 
+func (w *WAF) UnassignRulesFromRuleGroup(ctx context.Context, ruleGroupName string, token string, id string) error {
+	_, err := w.client.UpdateRuleGroup(ctx, &wafv2.UpdateRuleGroupInput{
+		Name:        aws.String(ruleGroupName),
+		Scope:       wafv2types.Scope(w.config.Scope),
+		LockToken:   aws.String(token),
+		Id:          aws.String(id),
+		Rules:       []wafv2types.Rule{},
+		VisibilityConfig: &wafv2types.VisibilityConfig{
+			SampledRequestsEnabled:   false,
+			CloudWatchMetricsEnabled: false,
+			MetricName:               aws.String(ruleGroupName),
+		},
+	})
+
+	return err
+}
+
 func (w *WAF) ListWebACL(ctx context.Context) (map[string]Acl, error) {
 	acls := make(map[string]Acl)
 
@@ -416,9 +433,11 @@ func (w *WAF) GetRuleGroup(ctx context.Context, ruleGroupname string) (string, w
 }
 
 func (w *WAF) CleanupAcl(ctx context.Context, acl *wafv2types.WebACL, token *string, allSets bool) error {
-	err := w.RemoveRuleGroupFromACL(ctx, acl, token)
-	if err != nil {
-		return fmt.Errorf("error removing rule group from ACL: %w", err)
+	if !w.config.DelegateAclManagement {
+		err := w.RemoveRuleGroupFromACL(ctx, acl, token)
+		if err != nil {
+			return fmt.Errorf("error removing rule group from ACL: %w", err)
+		}
 	}
 
 	if _, ok := w.ruleGroupsInfos[w.config.RuleGroupName]; ok {
@@ -429,9 +448,16 @@ func (w *WAF) CleanupAcl(ctx context.Context, acl *wafv2types.WebACL, token *str
 
 		w.Logger.Debugf("Deleting RuleGroup %s", w.config.RuleGroupName)
 
-		err = w.DeleteRuleGroup(ctx, w.config.RuleGroupName, token, w.ruleGroupsInfos[w.config.RuleGroupName].Id)
-		if err != nil {
-			return fmt.Errorf("failed to delete RuleGroup %s: %w", w.config.RuleGroupName, err)
+		if !w.config.DelegateAclManagement {
+			err = w.DeleteRuleGroup(ctx, w.config.RuleGroupName, token, w.ruleGroupsInfos[w.config.RuleGroupName].Id)
+			if err != nil {
+				return fmt.Errorf("failed to delete RuleGroup %s: %w", w.config.RuleGroupName, err)
+			}
+		} else {
+			err = w.UnassignRulesFromRuleGroup(ctx, w.config.RuleGroupName, token, w.ruleGroupsInfos[w.config.RuleGroupName].Id)
+			if err != nil {
+				return fmt.Errorf("failed to unassign Rules from RuleGroup %s: %w", w.config.RuleGroupName, err)
+			}
 		}
 	} else {
 		log.Debugf("RuleGroup %s not found, nothing to do", w.config.RuleGroupName)
@@ -526,24 +552,26 @@ func (w *WAF) Init(ctx context.Context) error {
 		return fmt.Errorf("failed to list resources: %w", err)
 	}
 
-	err = w.CreateRuleGroup(ctx, w.config.RuleGroupName)
+	if !w.config.DelegateAclManagement {
+		err = w.CreateRuleGroup(ctx, w.config.RuleGroupName)
 
-	if err != nil {
-		return fmt.Errorf("failed to create RuleGroup %s: %w", w.config.RuleGroupName, err)
-	}
+		if err != nil {
+			return fmt.Errorf("failed to create RuleGroup %s: %w", w.config.RuleGroupName, err)
+		}
 
-	w.Logger.Infof("RuleGroup %s created", w.config.RuleGroupName)
+		w.Logger.Infof("RuleGroup %s created", w.config.RuleGroupName)
 
-	acl, lockTocken, err := w.GetWebACL(ctx, w.config.WebACLName, w.aclsInfo[w.config.WebACLName].Id)
+		acl, lockTocken, err := w.GetWebACL(ctx, w.config.WebACLName, w.aclsInfo[w.config.WebACLName].Id)
 
-	if err != nil {
-		return fmt.Errorf("failed to get WebACL %s: %w", w.config.WebACLName, err)
-	}
+		if err != nil {
+			return fmt.Errorf("failed to get WebACL %s: %w", w.config.WebACLName, err)
+		}
 
-	err = w.AddRuleGroupToACL(ctx, acl, lockTocken)
+		err = w.AddRuleGroupToACL(ctx, acl, lockTocken)
 
-	if err != nil {
-		return fmt.Errorf("failed to add RuleGroup %s to WebACL %s: %w", w.config.RuleGroupName, w.config.WebACLName, err)
+		if err != nil {
+			return fmt.Errorf("failed to add RuleGroup %s to WebACL %s: %w", w.config.RuleGroupName, w.config.WebACLName, err)
+		}
 	}
 
 	return nil

--- a/pkg/waf/waf.go
+++ b/pkg/waf/waf.go
@@ -221,18 +221,14 @@ func (w *WAF) DeleteRuleGroup(ctx context.Context, ruleGroupName string, token s
 	return err
 }
 
-func (w *WAF) UnassignRulesFromRuleGroup(ctx context.Context, ruleGroupName string, token string, id string) error {
+func (w *WAF) UnassignRulesFromRuleGroup(ctx context.Context, ruleGroup wafv2types.RuleGroup, token string) error {
 	_, err := w.client.UpdateRuleGroup(ctx, &wafv2.UpdateRuleGroupInput{
-		Name:        aws.String(ruleGroupName),
-		Scope:       wafv2types.Scope(w.config.Scope),
-		LockToken:   aws.String(token),
-		Id:          aws.String(id),
-		Rules:       []wafv2types.Rule{},
-		VisibilityConfig: &wafv2types.VisibilityConfig{
-			SampledRequestsEnabled:   false,
-			CloudWatchMetricsEnabled: false,
-			MetricName:               aws.String(ruleGroupName),
-		},
+		Name:             ruleGroup.Name,
+        Id:               ruleGroup.Id,
+        Scope:            wafv2types.Scope(w.config.Scope),
+        LockToken:        aws.String(token),
+        Rules:            []wafv2types.Rule{},
+        VisibilityConfig: ruleGroup.VisibilityConfig,
 	})
 
 	return err
@@ -441,7 +437,7 @@ func (w *WAF) CleanupAcl(ctx context.Context, acl *wafv2types.WebACL, token *str
 	}
 
 	if _, ok := w.ruleGroupsInfos[w.config.RuleGroupName]; ok {
-		token, _, err := w.GetRuleGroup(ctx, w.config.RuleGroupName)
+		token, rg, err := w.GetRuleGroup(ctx, w.config.RuleGroupName)
 		if err != nil {
 			return fmt.Errorf("failed to get RuleGroup %s: %w", w.config.RuleGroupName, err)
 		}
@@ -456,7 +452,7 @@ func (w *WAF) CleanupAcl(ctx context.Context, acl *wafv2types.WebACL, token *str
 		} else {
 			w.Logger.Debugf("Cleaning RuleGroup %s", w.config.RuleGroupName)
 
-			err = w.UnassignRulesFromRuleGroup(ctx, w.config.RuleGroupName, token, w.ruleGroupsInfos[w.config.RuleGroupName].Id)
+			err = w.UnassignRulesFromRuleGroup(ctx, rg, token)
 			if err != nil {
 				return fmt.Errorf("failed to unassign Rules from RuleGroup %s: %w", w.config.RuleGroupName, err)
 			}

--- a/pkg/waf/waf.go
+++ b/pkg/waf/waf.go
@@ -224,11 +224,11 @@ func (w *WAF) DeleteRuleGroup(ctx context.Context, ruleGroupName string, token s
 func (w *WAF) UnassignRulesFromRuleGroup(ctx context.Context, ruleGroup wafv2types.RuleGroup, token string) error {
 	_, err := w.client.UpdateRuleGroup(ctx, &wafv2.UpdateRuleGroupInput{
 		Name:             ruleGroup.Name,
-        Id:               ruleGroup.Id,
-        Scope:            wafv2types.Scope(w.config.Scope),
-        LockToken:        aws.String(token),
-        Rules:            []wafv2types.Rule{},
-        VisibilityConfig: ruleGroup.VisibilityConfig,
+    	Id:               ruleGroup.Id,
+    	Scope:            wafv2types.Scope(w.config.Scope),
+    	LockToken:        aws.String(token),
+    	Rules:            []wafv2types.Rule{},
+    	VisibilityConfig: ruleGroup.VisibilityConfig,
 	})
 
 	return err


### PR DESCRIPTION
## Summary
* **Adds support for delegated ACL management**: Allows the bouncer to update RuleGroup without requiring full IAM `wafv2:UpdateWebACL`  permissions on the global WebACL managing CloudFront distributions.
* **Decouples Security Operations**: Enables a clear separation between infrastructure management (WebACL structure) and security automation (IP blocking).
* **Reduces IAM Blast Radius**: The bouncer now only requires permissions to update specific `RuleGroup` resources, adhering to the principle of least privilege.
* **Backward Compatible**: This is an opt-in feature; the bouncer maintains its default behavior of direct WebACL management if not configured otherwise.
* **Related to [Crowdsec AWS WAF bouncer to manage an existing RuleGroup](https://github.com/crowdsecurity/cs-aws-waf-bouncer/issues/88)**

## Changes
* **Updated: `pkg/cfg/config.go`**
    * Added `delegate_acl_management` (boolean) to the configuration structure.
* **New: `pkg/waf/waf.go`**
    * Implements the conditional logic to sync decisions to a RuleGroup.
    * Bypasses the requirement to create, modify and delete the `WebACL` object itself.
    * Bypasses the requirement to  create/delete the `RuleGroup`.
    * Implemented a function to unassign Rules from the RuleGroup, ensuring that associated IPSets can be cleaned up.

---
> **Note**: Users must manually create the "RuleGroup" object itself and assign it in their WebACL before enabling this mode, as the bouncer will no longer have permissions to alter the WebACL structure.